### PR TITLE
Fix setting gain to 100 on cameras that don't have a gain quirk

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -407,7 +407,6 @@ public class VisionModule {
 
         visionSource.getSettables().setVideoModeInternal(pipelineSettings.cameraVideoModeIndex);
         visionSource.getSettables().setBrightness(pipelineSettings.cameraBrightness);
-        visionSource.getSettables().setGain(pipelineSettings.cameraGain);
 
         // If manual exposure, force exposure slider to be valid
         if (!pipelineSettings.cameraAutoExposure) {


### PR DESCRIPTION
The call to setGain happens twice in VisionModule. The first time doesn't check for gain==-1, which indicates that the gain shouldn't be set. This PR removes that line. 